### PR TITLE
Changing the mode of transformed data write

### DIFF
--- a/StationConsumer/src/main/scala/com/tw/apps/OverwriteCSVSink.scala
+++ b/StationConsumer/src/main/scala/com/tw/apps/OverwriteCSVSink.scala
@@ -17,7 +17,7 @@ class OverwriteCSVSink(sqlContext: SQLContext,
       data.sparkSession.sparkContext.parallelize(data.collect()), data.schema)
       .repartition(1)
       .write
-      .mode(SaveMode.Overwrite)
+      .mode(SaveMode.Append)
       .format("csv")
       .option("header", parameters.get("header").orNull)
       .option("truncate", parameters.get("truncate").orNull)


### PR DESCRIPTION
Currently the transformed data (i.e. csv files) are being constantly overwritten whenever the StationConsumer job gets run. This deleted the historical data which might be needed for analysis.

This PR modifies the mode to `Append` i.e. the csv files will be appended going forth.

cc: @tw-ayush 